### PR TITLE
Enable passing FAL_KEY as an environment variable

### DIFF
--- a/nodes/image_node.py
+++ b/nodes/image_node.py
@@ -16,10 +16,13 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 try:
-    fal_key = config['API']['FAL_KEY']
-    os.environ["FAL_KEY"] = fal_key
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
 except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    print("Error: FAL_KEY not found in config.ini or environment variables")
 
 # Create the client with API key
 fal_client = SyncClient(key=fal_key)

--- a/nodes/llm_node.py
+++ b/nodes/llm_node.py
@@ -10,10 +10,13 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 try:
-    fal_key = config['API']['FAL_KEY']
-    os.environ["FAL_KEY"] = fal_key
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
 except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    print("Error: FAL_KEY not found in config.ini or environment variables")
 
 # Create the client with API key
 fal_client = SyncClient(key=fal_key)

--- a/nodes/trainer_node.py
+++ b/nodes/trainer_node.py
@@ -14,11 +14,15 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 try:
-    fal_key = config['API']['FAL_KEY']
-    os.environ["FAL_KEY"] = fal_key
-except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
 
+except KeyError:
+    print("Error: FAL_KEY not found in config.ini or environment variables")
+    
 # Create the client with API key
 fal_client = SyncClient(key=fal_key)
 

--- a/nodes/upscaler_node.py
+++ b/nodes/upscaler_node.py
@@ -16,10 +16,14 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 try:
-    fal_key = config['API']['FAL_KEY']
-    os.environ["FAL_KEY"] = fal_key
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
+
 except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    print("Error: FAL_KEY not found in config.ini or environment variables")
 
 # Create the client with API key
 fal_client = SyncClient(key=fal_key)

--- a/nodes/video_node.py
+++ b/nodes/video_node.py
@@ -20,12 +20,14 @@ config.read(config_path)
 
 # First set environment variable
 try:
-    fal_key = config['API']['FAL_KEY']
-
-    os.environ["FAL_KEY"] = fal_key
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
 
 except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    print("Error: FAL_KEY not found in config.ini or environment variables")
 
 # Create the client with your API key
 fal_client = SyncClient(key=fal_key)

--- a/nodes/vlm_node.py
+++ b/nodes/vlm_node.py
@@ -14,11 +14,14 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 try:
-    fal_key = config['API']['FAL_KEY']
-    os.environ["FAL_KEY"] = fal_key
-except KeyError:
-    print("Error: FAL_KEY not found in config.ini")
+    if os.environ.get("FAL_KEY"):
+        fal_key = os.environ["FAL_KEY"]
+    else:
+        fal_key = config['API']['FAL_KEY']
+        os.environ["FAL_KEY"] = fal_key
 
+except KeyError:
+    print("Error: FAL_KEY not found in config.ini or environment variables")
 # Create the client with API key
 fal_client = SyncClient(key=fal_key)
 


### PR DESCRIPTION
Currently it's not possible to pass FAL_KEY as an env var.
The value has a placeholder in config.ini by default, and then the env var is overwritten with that placeholder at runtime anyways. I made some small changes that should allow for this to work with both env vars and config file.