### PR TITLE
ModuleNotFoundError: No module named 'cv2'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fal-client
 torch
+opencv-python


### PR DESCRIPTION
When you try to run this custom node on a fresh copy of ComfyUI, it fails with:

```
Traceback (most recent call last):
  File "/Users/jin/dev/ComfyUI/nodes.py", line 2129, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jin/dev/ComfyUI/custom_nodes/ComfyUI-fal-API/__init__.py", line 17, in <module>
    imported_module = importlib.import_module(f".nodes.{module_name}", __name__)
  File "/opt/homebrew/Caskroom/miniconda/base/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jin/dev/ComfyUI/custom_nodes/ComfyUI-fal-API/nodes/video_node.py", line 5, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'

Cannot import /Users/jin/dev/ComfyUI/custom_nodes/ComfyUI-fal-API module for custom nodes: No module named 'cv2'

Import times for custom nodes:
   0.0 seconds: /Users/jin/dev/ComfyUI/custom_nodes/websocket_image_save.py
   0.0 seconds: /Users/jin/dev/ComfyUI/custom_nodes/bfl-comfy-nodes
   0.1 seconds (IMPORT FAILED): /Users/jin/dev/ComfyUI/custom_nodes/ComfyUI-fal-API
```